### PR TITLE
[RFC] Add a compat layer for Guard::API

### DIFF
--- a/lib/guard/compat/example.rb
+++ b/lib/guard/compat/example.rb
@@ -2,33 +2,37 @@
 # a stub will be supplied by the test class
 
 module Guard
-  class MyPlugin < Plugin
-    def start
-      Guard::Compat::UI.notify('foo')
-      Guard::Compat::UI.color('foo')
+  module MyPlugin
+    class Plugin
+      include Compat::API
 
-      Guard::Compat::UI.info('foo')
-      Guard::Compat::UI.warning('foo')
-      Guard::Compat::UI.error('foo')
-      Guard::Compat::UI.debug('foo')
-      Guard::Compat::UI.deprecation('foo')
-    end
+      def start
+        Guard::Compat::UI.notify('foo')
+        Guard::Compat::UI.color('foo')
 
-    def run_all
-      Guard::Compat::UI.notify('foo', bar: :baz)
-      Guard::Compat::UI.color('foo', :white)
+        Guard::Compat::UI.info('foo')
+        Guard::Compat::UI.warning('foo')
+        Guard::Compat::UI.error('foo')
+        Guard::Compat::UI.debug('foo')
+        Guard::Compat::UI.deprecation('foo')
+      end
 
-      Guard::Compat::UI.info('foo', bar: :baz)
-      Guard::Compat::UI.warning('foo', bar: :baz)
-      Guard::Compat::UI.error('foo', bar: :baz)
-      Guard::Compat::UI.debug('foo', bar: :baz)
-      Guard::Compat::UI.deprecation('foo', bar: :baz)
-    end
+      def run_all
+        Guard::Compat::UI.notify('foo', bar: :baz)
+        Guard::Compat::UI.color('foo', :white)
 
-    def run_on_modifications
-      Guard::Compat::UI.color_enabled?
-      Guard::Compat.matching_files(self, ['foo'])
-      Guard::Compat.watched_directories
+        Guard::Compat::UI.info('foo', bar: :baz)
+        Guard::Compat::UI.warning('foo', bar: :baz)
+        Guard::Compat::UI.error('foo', bar: :baz)
+        Guard::Compat::UI.debug('foo', bar: :baz)
+        Guard::Compat::UI.deprecation('foo', bar: :baz)
+      end
+
+      def run_on_modifications
+        Guard::Compat::UI.color_enabled?
+        Guard::Compat.matching_files(self, ['foo'])
+        Guard::Compat.watched_directories
+      end
     end
   end
 end

--- a/lib/guard/compat/plugin.rb
+++ b/lib/guard/compat/plugin.rb
@@ -51,6 +51,17 @@ module Guard
       end
     end
 
+    module API
+      def self.included(base)
+        if base.ancestors.any? { |c| c.name == 'Guard::Plugin' }
+          fail ArgumentError, 'You cannot include Guard::Compat::API in a'\
+            " class that inherits from Guard::Plugin: #{base.name}"
+        end
+
+        base.include(Guard::API) if Guard.const_defined?('API')
+      end
+    end
+
     module UI
       def self.color(text, *colors)
         if Guard.const_defined?(:UI)

--- a/lib/guard/compat/test/helper.rb
+++ b/lib/guard/compat/test/helper.rb
@@ -16,6 +16,15 @@ module Guard
     remove_method(:old_initialize)
   end
 
+  # Monkey patch API to just keep the interface
+  module API
+    attr_reader :options
+
+    def initialize(options = {})
+      @options = options
+    end
+  end
+
   # Stub, but allow real Notifier to be used, because e.g. guard-minitest uses
   # is while guard-process is being tested
   unless Guard.const_defined?('Notifier')

--- a/spec/guard/compat/example_spec.rb
+++ b/spec/guard/compat/example_spec.rb
@@ -2,7 +2,7 @@
 require 'guard/compat/test/helper'
 require 'guard/compat/example'
 
-RSpec.describe Guard::MyPlugin, exclude_stubs: [Guard::Plugin] do
+RSpec.describe Guard::MyPlugin::Plugin do
   let(:options) { { foo: :bar } }
   subject { described_class.new(options) }
 


### PR DESCRIPTION
This is a new module that can be mixed-in instead of inheriting from Guard::Plugin.

See https://github.com/guard/guard/pull/873 for the Guard::API implementation
